### PR TITLE
jsx-sort-prop-types is deprecated + убираем проверку в stylus на переменные с долларом

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -186,7 +186,7 @@
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-undef": 2,
     "jsx-quotes": [2, "prefer-single"],
-    "react/jsx-sort-prop-types": 1,
+    "react/sort-prop-types": 1,
     "react/jsx-sort-props": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,

--- a/.stylintrc
+++ b/.stylintrc
@@ -13,7 +13,7 @@
   "none": "always", // prefers border none over border 0
   "parenSpace": "never", // prefers mixin($param) over mixin( $param )
   "placeholders": false, // doesn't check for placeholders
-  "prefixVarsWithDollar": "always", // prefers $var = 0 over var = 0
+  "prefixVarsWithDollar": false, // doesn't check for prefixing vars with dollar
   "quotePref": "single", // prefers $var = 'something' over $var = "something"
   "semicolons": "never", // prefers margin 0 over margin 0;
   "sortOrder": false, // doesn't check for sort order of properties


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react#user-content-list-of-supported-rules
