### PR TITLE
the ecmaFeatures property is now under a top-level parserOptions prop…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,22 +9,24 @@
     "browser": true,                 // browser global variables
     "node": true                     // node.js global variables and node.js-specific rules
   },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": false,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": false,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true
+  "parserOptions": {
+    "ecmaFeatures": {
+      "arrowFunctions": true,
+      "blockBindings": true,
+      "classes": true,
+      "defaultParams": true,
+      "destructuring": true,
+      "forOf": true,
+      "generators": false,
+      "modules": true,
+      "objectLiteralComputedProperties": true,
+      "objectLiteralDuplicateProperties": false,
+      "objectLiteralShorthandMethods": true,
+      "objectLiteralShorthandProperties": true,
+      "spread": true,
+      "superInFunctions": true,
+      "templateStrings": true
+    }
   },
   "rules": {
     "compat/compat": 2,

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,12 @@ describe('eslint.index', function() {
     expect(exporter).have.an.property('parser').is.equal('babel-eslint');
   });
 
-  it('function should contain `ecmaFeatures` attribute', function() {
-    expect(exporter).have.an.property('ecmaFeatures');
+  it('function should contain `parserOptions` attribute', function() {
+    expect(exporter).have.an.property('parserOptions');
+  });
+
+  it('function should contain `parserOptions.ecmaFeatures` attribute', function() {
+    expect(exporter.parserOptions).have.an.property('ecmaFeatures');
   });
 
   it('function should contain `rules` attribute', function() {


### PR DESCRIPTION
…erty

В eslint версии 2.0.0 свойство ecmaFeatures в конфиге было перемещено внутрь parserOptions.
А в версии 4.0.0 неизвестные свойства на верхнем уровне стали вызывать fatal error. 